### PR TITLE
Add footer with (broken) links to TOS, etc

### DIFF
--- a/node/frontend/index.html
+++ b/node/frontend/index.html
@@ -168,11 +168,22 @@
 			min-height: 150px;
 		}
 
+		body {
+			display: flex;
+			min-height: 100vh;
+			flex-direction: column;
+		}
+
+		main {
+			flex: 1 0 auto;
+		}
+
 	</style>
 
 </head>
 <body>
 
+<header>
 <nav class="nav-extended transparent z-depth-0" id="main_nav">
 	<div class="nav-wrapper">
 		<a href="/"
@@ -232,7 +243,8 @@
 		</ul>
 	</div>
 </nav>
-
+</header>
+<main>
 <div class="container" style="margin:0;padding-left:10px"> <!-- No idea why this padding adjustment is necessary... -->
 
 
@@ -354,7 +366,7 @@
 		</div>
 	</div>
 </div>
-
+</main>
 
 
 <!-- Modal 1 -->
@@ -569,5 +581,22 @@
 	</form>
 </div>
 
+<footer class="footer-copyright">
+	<div class="container">
+		<div class="row valign-wrapper">
+			<div class="col s6 valign-wrapper">
+					<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+						<img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png">
+					</a>
+					<span style="margin-left: 15px;">© Mediachain Labs</span>
+			</div>
+			<div class="col s6 valign-wrapper">
+				<a href="/terms-of-service" style="margin-left: 15px;">Terms of Service</a>
+				<a href="/privacy-policy" style="margin-left: 15px;">Privacy Policy</a>
+				<a href="/copyright-policy" style="margin-left: 15px;">DMCA Copyright Policy</a>
+			</div>
+		</div>
+	</div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
![screen shot 2017-03-03 at 5 59 47 pm](https://cloud.githubusercontent.com/assets/678715/23572158/398eae74-003b-11e7-9b77-fad2bd8bfa9c.png)

Links are to `/terms-of-service`, `/privacy-policy` and `/copyright-policy` but there's nothing there yet.

I'll try to whip up some static pages for those rq with copy/pasted text from AE, but not sure if I can get it done by EOD.