### PR TITLE
Read mediachain api url from env, write to mc if present

### DIFF
--- a/node/node_core.py
+++ b/node/node_core.py
@@ -203,7 +203,7 @@ class CCCoinCore:
                  fake_id_testing_mode = False,
                  settings_rewards = {},
                  genesis_users = [],
-                 write_to_mc = False,
+                 mediachain_api_url = False,
                  ):
         """
         Note: Either `the_code` or `the_address` should be supplied to the contract.
@@ -223,9 +223,9 @@ class CCCoinCore:
         assert settings_rewards
         
         self.rw = settings_rewards
-        
-        if write_to_mc:
-            self.mcq = MediachainQueue(default_namespace = 'cccoin')
+
+        if mediachain_api_url:
+            self.mcq = MediachainQueue(mc_api_url=mediachain_api_url, default_namespace = 'cccoin')
         else:
             self.mcq = False
         

--- a/node/node_main.py
+++ b/node/node_main.py
@@ -19,6 +19,10 @@ WEB_NODE_APPROVAL_ACCOUNTS = environ.get('WEB_NODE_FLAG_ACCOUNTS', '').split(','
 ## See cccoin/docs/nginx_config for nginx setup, or set to False to disable.:
 IMAGE_PROXY_PATH = environ.get('IMAGE_PROXY_PATH', False)
 
+## Set to root url of mediachain http api, e.g. `http://localhost:9002` to enable
+## writing to mediachain when a post is confirmed by the blockchain
+MC_API_URL = environ.get('MEDIACHAIN_API_URL', False)
+
 DATA_DIR = 'build_contracts/'
 
 DEPLOY_WITH_TRUFFLE = True
@@ -518,8 +522,9 @@ def start_inner(mode,
     cccoin = CCCoinCore(contract_wrapper = cw,
                         settings_rewards = CORE_SETTINGS,
                         mode = mode,
-                        ) 
-    
+                        mediachain_api_url=MC_API_URL,
+                        )
+
     cw.start_contract_thread(start_in_foreground = (mode != 'web'),
                              terminate_on_exception = (mode != 'web'),
                              )

--- a/node/test_mc.py
+++ b/node/test_mc.py
@@ -15,7 +15,6 @@ from tornado.ioloop import IOLoop
 # pytest fixture configuration (see conftest.py)
 
 contract_args = {'start_at_current_block': True, 'settings_confirm_states': {'BLOCKCHAIN_CONFIRMED':1}}
-cccoin_core_args = {'write_to_mc': True}
 
 @pytest.fixture
 def mc_node_url(tmpdir):


### PR DESCRIPTION
This changes the `write_to_mc` arg in the `CCCoinCore` constructor from a boolean to a `mediachain_api_url` string, which gets passed into the `MediachainQueue` constructor if its set.

In `node_main.py`, we check for a `MEDIACHAIN_API_URL` environment variable, and pass it into the constructor if it's present.

With this approach, we need to take care to only set the env variable for one cccoin process (either when we run the web node or the rewards node), to avoid writing multiple records for each post.